### PR TITLE
Update tools and dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,25 +1,19 @@
 buildscript {
     ext {
-        springBootVersion = '2.0.6.RELEASE'
-    }
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
-        classpath('gradle.plugin.com.palantir.gradle.docker:gradle-docker:0.13.0')
+        springBootVersion = '2.2.0.RELEASE'
+        lombokVersion = '1.18.10'
+        swaggerVersion = '2.9.2'
     }
 }
 
 plugins {
-    id 'org.unbroken-dome.test-sets' version '2.1.1'
+    id 'java'
+    id 'eclipse'
+    id 'org.springframework.boot' version "$springBootVersion"
+    id "io.spring.dependency-management" version "1.0.8.RELEASE"
+    id 'com.palantir.docker' version '0.22.1'
+    id 'org.unbroken-dome.test-sets' version '2.2.1'
 }
-
-apply plugin: 'java'
-apply plugin: 'eclipse'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-apply plugin: 'com.palantir.docker'
 
 group = 'com.github.manedev79'
 version = '1.0.1-SNAPSHOT'
@@ -34,16 +28,15 @@ testSets {
 }
 
 dependencies {
-    annotationProcessor 'org.projectlombok:lombok:1.18.4'
+    annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
     implementation 'org.springframework.boot:spring-boot-starter-validation:'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'io.springfox:springfox-swagger2:2.9.2'
-    implementation 'io.springfox:springfox-swagger-ui:2.9.2'
-    implementation 'org.projectlombok:lombok:1.18.4'
+    implementation "io.springfox:springfox-swagger2:${swaggerVersion}"
+    implementation "io.springfox:springfox-swagger-ui:${swaggerVersion}"
+    implementation "org.projectlombok:lombok:${lombokVersion}"
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     implementation "org.springframework.boot:spring-boot-starter-data-mongodb"
     runtimeOnly 'org.springframework.boot:spring-boot-devtools'
-    runtimeOnly 'com.h2database:h2:1.4.197'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-webflux'
     testImplementation 'org.assertj:assertj-core:3.6.2'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip


### PR DESCRIPTION
Update spring-boot to 2.2.0.RELEASE.
Update gradle to 5.6.4.
Update dependencies and plugins.
Ensure there are no deprecation warnings regarding gradle 6.